### PR TITLE
fix(styles): include Select styles in global bundle

### DIFF
--- a/.changeset/include-select-styles.md
+++ b/.changeset/include-select-styles.md
@@ -1,0 +1,8 @@
+---
+"@johnatandeleon/design-system": patch
+---
+
+Fix: include Select component styles in the global styles bundle.
+
+- Ensure consumers importing `@johnatandeleon/design-system/styles` receive Select CSS.
+- No API changes. CSS-only fix to align Select with Button/Input/Card export behavior.

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -9,3 +9,4 @@
 import "./styles/recipes/button.css";
 import "./styles/recipes/card.css";
 import "./styles/recipes/input.css";
+import "./styles/recipes/select.css";


### PR DESCRIPTION
Se incluye el CSS del componente Select en el bundle global de estilos y se añade un changeset patch.

Cambios:
- import ./styles/recipes/select.css en `src/styles.ts`
- new changeset: `.changeset/include-select-styles.md` (patch)

Motivo: consumidores que importan `@johnatandeleon/design-system/styles` no estaban recibiendo los estilos de Select.

Incluye también los cambios previos de la rama: incorporación del componente Select y mejoras en Input.