### PR TITLE
fix(select): normalize Select large height to 48px

### DIFF
--- a/.changeset/fix-select-height.md
+++ b/.changeset/fix-select-height.md
@@ -1,0 +1,8 @@
+---
+"@johnatandeleon/design-system": patch
+---
+
+Force explicit height and line-height for the Select component (large size) to match Input sizing (48px). This fixes a 2px visual mismatch between Input and Select in the large size.
+
+- Add explicit `height` and `lineHeight` to the overlay `selectTrigger` and native `selectField` large variants.
+- This change aligns Select with Input visual sizing and improves cross-browser consistency.

--- a/src/styles/recipes/select.css.ts
+++ b/src/styles/recipes/select.css.ts
@@ -216,8 +216,9 @@ export const selectFieldMedium = style({
 });
 
 export const selectFieldLarge = style({
-  // Larger control without forcing line-height to equal the element height
-  minHeight: spacing[12],
+  // Force explicit height/line-height to match Input large sizing (48px)
+  height: spacing[12],
+  lineHeight: spacing[12],
   padding: `${spacing[4]} ${spacing[5]}`,
   fontSize: typography.fontSize.base,
 });
@@ -366,7 +367,9 @@ const triggerMd = style({
   fontSize: typography.fontSize.sm,
 });
 const triggerLg = style({
-  minHeight: spacing[12],
+  // Force exact control height for parity with Input large (48px)
+  height: spacing[12],
+  lineHeight: spacing[12],
   padding: `${spacing[4]} ${spacing[5]}`,
   fontSize: typography.fontSize.base,
 });


### PR DESCRIPTION
Force explicit height and line-height for Select large variant to match Input and fix 2px visual mismatch. Includes changeset.